### PR TITLE
ci: 新增 server 和 client 的 TypeScript 型別檢查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
       - name: Install server dependencies
         run: cd server && npm install
 
+      - name: Install client dependencies
+        run: cd client && npm install
+
+      - name: Typecheck server
+        run: cd server && npx tsc --noEmit
+
+      - name: Typecheck client
+        run: cd client && npx tsc --noEmit
+
       - name: Run server tests
         run: cd server && npm test
         env:


### PR DESCRIPTION
## Summary
- CI 新增 `tsc --noEmit` 步驟，涵蓋 server 和 client
- 型別檢查在測試之前執行，提早攔截型別錯誤
- 防止 PR #4 類型的問題（TS2322 只在 Render deploy 才暴露）

Closes #6

## Test plan
- [x] `cd server && npx tsc --noEmit` 本地通過
- [x] `cd client && npx tsc --noEmit` 本地通過
- [ ] CI workflow 執行成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)